### PR TITLE
Alter check for element to complain less.

### DIFF
--- a/slurp_XML_converted_JSON_to_solr.xslt
+++ b/slurp_XML_converted_JSON_to_solr.xslt
@@ -9,7 +9,7 @@
     <xsl:param name="suffix">ms</xsl:param>
     <xsl:param name="root_node">json</xsl:param>
 
-    <xsl:apply-templates mode="index_converted_json" select="$content/$root_node">
+    <xsl:apply-templates mode="index_converted_json" select="$content/*[local-name(self::node()) = $root_node]">
       <xsl:with-param name="prefix" select="$prefix"/>
       <xsl:with-param name="suffix" select="$suffix"/>
     </xsl:apply-templates>

--- a/slurp_XML_converted_JSON_to_solr.xslt
+++ b/slurp_XML_converted_JSON_to_solr.xslt
@@ -9,7 +9,7 @@
     <xsl:param name="suffix">ms</xsl:param>
     <xsl:param name="root_node">json</xsl:param>
 
-    <xsl:apply-templates mode="index_converted_json" select="$content/*[local-name(self::node()) = $root_node]">
+    <xsl:apply-templates mode="index_converted_json" select="$content/*[local-name() = $root_node]">
       <xsl:with-param name="prefix" select="$prefix"/>
       <xsl:with-param name="suffix" select="$suffix"/>
     </xsl:apply-templates>


### PR DESCRIPTION
Could complain with messages like:
```
SystemId Unknown; Line #12; Column #83; A relative location path was expected following the '/' or '//' token.
SystemId Unknown; Line #12; Column #83; Extra illegal tokens: '$', 'root_node'
```