### PR TITLE
Fix the old bug.

### DIFF
--- a/RELS-EXT_to_solr.xslt
+++ b/RELS-EXT_to_solr.xslt
@@ -103,7 +103,7 @@
                 <xsl:attribute name="name">
                   <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_intDerivedFromString_l')"/>
                 </xsl:attribute>
-                <xsl:value-of select="$value"/>
+                <xsl:value-of select="floor($value)"/>
               </field>
             </xsl:when>
           </xsl:choose>


### PR DESCRIPTION
`floor(1.0) == 1.0`, so it was attempting to use `1.0` as an integer...
... Solr itself wouldn't do any sort of casting, and fail to index the doc.
... Great fun!