### PR TITLE
Fix lang tag slurping

### DIFF
--- a/slurp_all_MODS_to_solr.xslt
+++ b/slurp_all_MODS_to_solr.xslt
@@ -286,6 +286,18 @@
         <xsl:with-param name="node" select="$node"/>
       </xsl:call-template>
     </xsl:if>
+
+    <!-- Look for @xml:lang tags too. -->
+    <xsl:if test="@xml:lang">
+      <xsl:call-template name="mods_authority_fork">
+        <xsl:with-param name="prefix" select="concat($prefix, 'lang_', translate(@xml:lang, $uppercase, $lowercase), '_')"/>
+        <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:with-param name="value" select="$value"/>
+        <xsl:with-param name="pid" select="$pid"/>
+        <xsl:with-param name="datastream" select="$datastream"/>
+        <xsl:with-param name="node" select="$node"/>
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
 
   <!-- Handle the actual indexing of the majority of MODS elements, including


### PR DESCRIPTION
It currently does index languages for all MODS fields, but
was just looking for @lang tags. This adds support for
@xml:lang tags (which is the XML way to do it anyway).